### PR TITLE
Fix segfaults on intel integrated graphics

### DIFF
--- a/include/graphics/textures.hpp
+++ b/include/graphics/textures.hpp
@@ -69,6 +69,9 @@ class texture {
     }
 
     void fill_texture(std::vector<T>& data) {
+	// In reference to the hack in the 3D fill_texture below, we
+	// have found that 1x1 textures are supported in intel
+	// integrated graphics.
         glBindTexture(GL_TEXTURE_2D, texture_id_);
 
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
@@ -125,6 +128,13 @@ class texture3d {
     }
 
     void fill_texture(std::vector<T>& data) {
+	// This is a hack to prevent segfaults on laptops with integrated intel graphics.
+	// For some reason, the i965_dri.so module crashes on textures smaller than 8x8x8 pixels.
+	if (x_ < 8 || y_ < 8 || z_ < 8) {
+	    std::cerr << "Showing a slice smaller than 8x8 pixels is not supported due to bugs in Intel GPU drivers\n" << std::endl;
+	    return ;
+	}
+
         glBindTexture(GL_TEXTURE_3D, texture_id_);
 
         glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);


### PR DESCRIPTION
I got segfaults on my laptop when running recast3d with the simple example from tomopackets (https://github.com/cicwi/TomoPackets/blob/master/examples/simple_example.py). 

@wjp and I found out that the i965_dri.so module crashes on textures smaller than 8x8x8 pixels.

Therefore, I have introduced a hack that prevents these textures from being drawn. To prevent confusion for the user, we print a message to the terminal. 
