### PR TITLE
Add conda packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/*
 build/
 test/build/
 data/
+*~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,9 @@ set_source_files_properties(
   COMPILE_FLAGS "-w"
 )
 
-add_library(imgui ${IMGUI_SOURCE_NAMES}) 
+add_library(imgui ${IMGUI_SOURCE_NAMES})
 target_link_libraries(imgui PUBLIC glfw)
+target_link_libraries(imgui PUBLIC dl)
 target_include_directories(imgui PUBLIC
     "ext/imgui"
     "ext/imgui/examples/libs/gl3w/"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,8 @@ else()
 endif()
 
 # --------------------------------------------------------------------------------------------
-# ZeroMQ
-find_package(ZeroMQ QUIET)
+# ZeroMQ version 4.X
+find_package(ZeroMQ 4 QUIET)
 
 if (ZeroMQ_FOUND AND NOT TARGET zmq)
     add_library(zmq INTERFACE)

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# First prepare glmConfig.cmake
+mkdir ext/glm/build && cd ext/glm/build
+cmake ..
+cd ../../../
+
+
+declare -a CMAKE_PLATFORM_FLAGS
+if [[ ${HOST} =~ .*linux.* ]]; then
+    CMAKE_PLATFORM_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE="${RECIPE_DIR}/cross-linux.cmake")
+fi
+
+mkdir build && cd build
+
+# We want to link against the anaconda-provided openGL, so we have to
+# set the preference to legacy.
+cmake ..                                        \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX            \
+      -DCMAKE_INSTALL_LIBDIR=$PREFIX/lib        \
+      -DCMAKE_BUILD_TYPE=Release                \
+      ${CMAKE_PLATFORM_FLAGS[@]}                \
+      -DOpenGL_GL_PREFERENCE="LEGACY"           \
+      -DGLFW_BUILD_EXAMPLES=OFF                 \
+      -DGLFW_BUILD_TESTS=OFF                    \
+      -DGLFW_BUILD_DOCS=OFF                     \
+      -Dglm_DIR="ext/glm/build"
+
+
+
+make -j $CPU_COUNT VERBOSE=1
+make install

--- a/conda/cross-linux.cmake
+++ b/conda/cross-linux.cmake
@@ -1,0 +1,19 @@
+# From: https://github.com/AnacondaRecipes/freeglut-feedstock/blob/master/recipe/cross-linux.cmake
+# See also: https://github.com/ContinuumIO/anaconda-issues/issues/8779
+
+# this one is important
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_PLATFORM Linux)
+
+# specify the cross compiler
+set(CMAKE_C_COMPILER $ENV{CC})
+set(CMAKE_CXX_COMPILER $ENV{CXX})
+
+# where is the target environment
+set(CMAKE_FIND_ROOT_PATH $ENV{PREFIX} $ENV{BUILD_PREFIX}/$ENV{HOST}/sysroot)
+
+# search for programs in the build host directories
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# for libraries and headers in the target directories
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -7,7 +7,7 @@ source:
   git_tag: master
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -47,13 +47,13 @@ requirements:
     - make
   host:
     - boost
-    - zeromq
+    - zeromq=4
     - eigen
     - pybind11
     - libxcb                            # [linux]
     - zlib
   run:
-    - zeromq
+    - zeromq=4
     - eigen
     - libxcb                            # [linux]
     - zlib

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,0 +1,69 @@
+package:
+  name: recast3d
+  version: 1.0.0.rc.1
+
+source:
+  git_url: https://github.com/cicwi/RECAST3D
+  git_tag: master
+
+build:
+  number: 1
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ cdt('libx11-common') }}
+    - {{ cdt('libx11-devel') }}
+    - {{ cdt('xorg-x11-proto-devel') }}
+    - {{ cdt('xorg-x11-server-common') }}
+    - {{ cdt('xorg-x11-server-xvfb') }}
+    - {{ cdt('xorg-x11-util-macros') }}
+    - {{ cdt('xorg-x11-xauth') }}
+    - {{ cdt('libxrandr-devel') }}
+    - {{ cdt('libxinerama-devel') }}
+    - {{ cdt('libxcursor-devel') }}
+    - {{ cdt('libxau-devel') }}
+    - {{ cdt('libdrm-devel') }}
+    - {{ cdt('mesa-libgl-devel') }}     # [linux]
+    - {{ cdt('mesa-libegl-devel') }}    # [linux]
+    - {{ cdt('mesa-dri-drivers') }}     # [linux]
+    - {{ cdt('xorg-x11-proto-devel') }} # [linux]
+    - {{ cdt('libx11-devel') }}         # [linux]
+    - {{ cdt('libxext-devel') }}        # [linux]
+    - {{ cdt('libxrender-devel') }}     # [linux]
+    - {{ cdt('libxcomposite-devel') }}  # [linux]
+    - {{ cdt('libxcursor-devel') }}     # [linux]
+    - {{ cdt('libxi-devel') }}          # [linux]
+    - {{ cdt('libselinux-devel') }}     # [linux]
+    - {{ cdt('libxrandr-devel') }}      # [linux]
+    - {{ cdt('libxdamage') }}           # [linux]
+    - {{ cdt('libxdamage-devel') }}     # [linux]
+    - {{ cdt('libxfixes') }}            # [linux]
+    - {{ cdt('libxfixes-devel') }}      # [linux]
+    - {{ cdt('libxxf86vm') }}           # [linux]
+    - pkg-config                        # [unix]
+    - cmake
+    - make
+  host:
+    - boost
+    - zeromq
+    - eigen
+    - pybind11
+    - libxcb                            # [linux]
+    - zlib
+  run:
+    - zeromq
+    - eigen
+    - libxcb                            # [linux]
+    - zlib
+
+test:
+  commands:
+    - test -f $PREFIX/bin/recast3d      # [unix]
+
+
+about:
+  home: https://github.com/cicwi/RECAST3D
+  license: GPLv3
+  summary: 'RECAST3D: Real-time visualization tool for tomographic data.'


### PR DESCRIPTION
This commit adds conda packaging for recast.

One change to the CMakeLists.txt was necessary to make it build correctly:
- Add imgui dependency on libdl
  - Imgui.a contains a call to dlclose. It thus has to be linked to libdl.

The conda recipe pulls the most recent source code from the master
branch of recast3d.  Because of the afore-mentioned change to
CMakeLists.txt, the conda recipe will not work until this pull request
is merged into master.

----------------------------------------------------------------------

I have chosen to split the dependencies as follows:

Conda provides the following dependencies:
- OpenGL (required) development libraries and headers
- ZeroMQ (submodule)
- Eigen (submodule)

The following packages are built from source (submodules):
- glm (required)
- GLFW (submodule)
- Assimp (submodule)
- ImGui (submodule)
- TomoPackets (submodule)

This one I am actually not sure about:
- cppzmq (submodule)

The packages assimp, glm, and glfw are not provided by the defaults
channel in anaconda. Conda-forge does provide these packages, but has
a different packaging philosophy for opengl and x11 that I am not sure
is maximally compatible across all devices. In any case, building the
dependencies from source allows us to build the conda package without
adding "-c conda-forge".

NOTE: I have added numerous dependecies to so-called CDTs in the build
requirements. I am sure these are not all required. Nonetheless, they
do not add any weight to the resulting package and are fast to
download. So I have decided against checking each and every CDT
dependency to see if it can be removed.

----------------------------------------------------------------------

I have updated the tomopackets dependency to the master branch.

----------------------------------------------------------------------

PS. I sneaked in a small change to .gitignore:
- Ignore files ending in ~